### PR TITLE
Add missing EXPOSE declaration to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,7 @@ ENV KAFKA_HOME /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}
 ADD start-kafka.sh /usr/bin/start-kafka.sh
 ADD broker-list.sh /usr/bin/broker-list.sh
 
+EXPOSE 9092
+
 # Use "exec" form so that it runs as PID 1 (useful for graceful shutdown)
 CMD ["start-kafka.sh"]


### PR DESCRIPTION
This makes a difference in the environment variables that are automatically added to containers linked to this.
